### PR TITLE
Fix default burp file logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -239,7 +239,8 @@ class SQLMapGenerator {
         this.setStandardConfigItem(config, '-g');
         this.setStandardConfigItem(config, '-m');
         this.setStandardConfigItem(config, '-l');
-        
+
+        const burpFile = document.getElementById('burpFile').value.trim();
         const burpFileScope = document.getElementById('burpFileScope').value.trim();
         if (burpFileScope) config['--scope'] = burpFileScope;
         if (burpFileScope && !burpFile) document.getElementById('burpFile').value = "burp.txt";


### PR DESCRIPTION
## Summary
- define `burpFile` before it is referenced
- use the variable when setting the default burp file value

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866340eb5dc8331b918d20de1f23f4a