### PR TITLE
Fix Q checkbox restore

### DIFF
--- a/app.js
+++ b/app.js
@@ -766,7 +766,7 @@ class SQLMapGenerator {
                     }
                     else if (param === '--technique') {
                         // Handle technique checkboxes
-                        ['B', 'E', 'U', 'S', 'T'].forEach(tech => {
+                        ['B', 'E', 'U', 'S', 'T', 'Q'].forEach(tech => {
                             const techElement = document.getElementById('tech' + tech);
                             if (techElement) {
                                 techElement.checked = value.includes(tech);


### PR DESCRIPTION
## Summary
- ensure inline query technique `Q` is restored from configuration

## Testing
- `python build.py` *(fails: No module named 'pytz')*

------
https://chatgpt.com/codex/tasks/task_e_68663412f7fc8331bafe7cc5832007e6